### PR TITLE
feat: Choice API 를 추가

### DIFF
--- a/src/account/account.entity.ts
+++ b/src/account/account.entity.ts
@@ -5,10 +5,10 @@ import { Question } from "src/question/question.entity";
 
 export class TimeEntity extends BaseEntity {
     @CreateDateColumn()
-    created_at: Date;
+    createdAt: Date;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updatedAt: Date;
 }
 
 @Entity()

--- a/src/question/question.controller.ts
+++ b/src/question/question.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { QuestionService } from './question.service';
-import { QuestionsResponse, QuestionDto, QuestionInCreate } from './question.dto';
+import { QuestionsResponse, QuestionDto, QuestionInCreate, ChoiceInCreate, ChoiceDto, ChoiceResponse } from './question.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { CurrentUser } from 'src/account/get-user.decorator';
 import { Account } from 'src/account/account.entity';
@@ -21,13 +21,13 @@ export class QuestionController {
         @CurrentUser() account: Account,
         @Body() QuestionInCreate: QuestionInCreate,
     ) {
-        const question = await this.questionService.create(account, QuestionInCreate);
+        const question = await this.questionService.createQuestion(account, QuestionInCreate);
         return new QuestionDto(question);
     }
 
 
     @ApiOperation({ summary: 'fetch questions' })
-    @ApiResponse({ status: 200,  type: QuestionsResponse })
+    @ApiResponse({ status: 200,  type: QuestionsResponse, isArray: true })
     @ApiQuery({ name: 'limit', required: false, type: Number })
     @ApiQuery({ name: 'offset', required: false, type: Number })
     @Get('/')
@@ -35,7 +35,7 @@ export class QuestionController {
         @Query('offset') offset: number = 0,
         @Query('limit') limit: number = 20,
     ) {
-        return await this.questionService.fetch(offset, limit);
+        return await this.questionService.fetchQuestions(offset, limit);
     }
     
     @ApiOperation({ summary: 'get question by id' })
@@ -45,8 +45,44 @@ export class QuestionController {
         @Query('id') id: number,
     ) {
         const question = await this.questionService.getQuestionById(id);
-        console.log(question)
         return new QuestionDto(question);
     }
+
+
+    @ApiOperation({ summary: 'fetch choice' })
+    @ApiResponse({ status: 200, type: [ChoiceResponse] })
+    @ApiQuery({ name: 'questionId', required: true, type: Number })
+    @ApiBearerAuth('JWT')
+    @UseGuards(AuthGuard('jwt'))
+    @Get('/:questionId/choices')
+    async fetchChoices(@CurrentUser() user: Account, @Query('questionId') questionId: number): Promise<ChoiceResponse[]> {
+        return await this.questionService.fetchChoices(user.id, questionId);
+    }
+
+    @ApiOperation({ summary: 'create choice' })
+    @ApiResponse({ status: 201 })
+    @ApiBearerAuth('JWT')
+    @UseGuards(AuthGuard('jwt'))
+    @Post('/:questionId/choices')
+    async createChoice(
+        @CurrentUser() user: Account,
+        @Query('questionId') questionId: number,
+        @Body() choiceInCreate: ChoiceInCreate,
+    ) {
+        const choice = await this.questionService.createChoice(user, questionId, choiceInCreate.value);
+        return new ChoiceDto(choice);
+    }
+
+    @ApiOperation({ summary: 'get choice by id' })
+    @ApiResponse({ status: 200, type: ChoiceDto })
+    @Get('/:questionId/choices/:choiceId')
+    async getChoiceById(
+        @Query('questionId') questionId: number,
+        @Query('choiceId') choiceId: number,
+    ) {
+        const choice = await this.questionService.getChoiceById(questionId, choiceId);
+        return new ChoiceDto(choice);
+    }
+
 
 }

--- a/src/question/question.dto.ts
+++ b/src/question/question.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsArray, ArrayMinSize, ArrayMaxSize, ValidateIf } from 'class-validator';
-import { Question } from './question.entity';
+import { Choice, Question } from './question.entity';
 
 
 export class QuestionInCreate {
@@ -31,44 +31,44 @@ export class QuestionInCreate {
 
 export class QuestionDto {
     
-        constructor(question: Question) {
-            this.id = question.id;
-            this.ownerId = question.owner.id;
-            this.title = question.title;
-            this.choiceList = question.choiceList;
-            this.backgroundImage = question.backgroundImage;
-            this.isOfficial = question.isOfficial;
-            this.isBlind = question.isBlind;
-            this.createdAt = question.created_at;
-            this.updatedAt = question.updated_at;
-        }
-    
-        @ApiProperty({example: 1})
-        id: number;
-        
-        @ApiProperty({example: 2})
-        ownerId: number;
+    constructor(question: Question) {
+        this.id = question.id;
+        this.ownerId = question.owner.id;
+        this.title = question.title;
+        this.choiceList = question.choiceList;
+        this.backgroundImage = question.backgroundImage;
+        this.isOfficial = question.isOfficial;
+        this.isBlind = question.isBlind;
+        this.createdAt = question.createdAt;
+        this.updatedAt = question.updatedAt;
+    }
 
-        @ApiProperty({example: '질문 제목'})
-        title: string;
+    @ApiProperty({example: 1})
+    id: number;
     
-        @ApiProperty({example: ['투표 선택지1', '투표 선택지2']})
-        choiceList: string[];
-    
-        @ApiProperty({example: 'https://qfeed-s3.s3.ap-northeast-2.amazonaws.com/files/github.png'})
-        backgroundImage: URL;
-    
-        @ApiProperty({example: false, default: false})
-        isOfficial: boolean;
-    
-        @ApiProperty({example: false, default: false})
-        isBlind: boolean;
+    @ApiProperty({example: 2})
+    ownerId: number;
 
-        @ApiProperty({example: new Date()})
-        createdAt: Date;
+    @ApiProperty({example: '질문 제목'})
+    title: string;
 
-        @ApiProperty({example: new Date()})
-        updatedAt: Date;
+    @ApiProperty({example: ['투표 선택지1', '투표 선택지2']})
+    choiceList: string[];
+
+    @ApiProperty({example: 'https://qfeed-s3.s3.ap-northeast-2.amazonaws.com/files/github.png'})
+    backgroundImage: URL;
+
+    @ApiProperty({example: false, default: false})
+    isOfficial: boolean;
+
+    @ApiProperty({example: false, default: false})
+    isBlind: boolean;
+
+    @ApiProperty({example: new Date()})
+    createdAt: Date;
+
+    @ApiProperty({example: new Date()})
+    updatedAt: Date;
 
 }
 
@@ -84,5 +84,77 @@ export class QuestionsResponse {
     
     @ApiProperty({example: [QuestionDto]})
     data: QuestionDto[];
+
+}
+
+export class QuestionDetailResponse {
+    
+    constructor( question: QuestionDto, choiceCount: { [key: string]: number; } ) {
+        this.question = question;
+        this.choiceCount = choiceCount;
+    }
+
+    question: QuestionDto;
+    choiceCount : { [key: string]: number; };
+    
+}
+
+
+export class ChoiceInCreate {
+
+    @ApiProperty({example: '투표 선택지1'})
+    @IsNotEmpty()
+    value: string;
+
+}
+
+export class ChoiceDto {
+        
+        constructor(choice: Choice) {
+            this.id = choice.id;
+            this.questionId = choice.question.id;
+            this.userId = choice.user.id;
+            this.value = choice.value;
+            this.createdAt = choice.createdAt;
+            this.updatedAt = choice.updatedAt;
+        }
+    
+        @ApiProperty({example: 1})
+        id: number;
+    
+        @ApiProperty({example: 1})
+        questionId: number;
+    
+        @ApiProperty({example: 1})
+        userId: number;
+    
+        @ApiProperty({example: '투표 선택지1'})
+        value: string;
+    
+        @ApiProperty({example: new Date()})
+        createdAt: Date;
+    
+        @ApiProperty({example: new Date()})
+        updatedAt: Date;
+    
+}
+
+export class ChoiceResponse {
+        
+    constructor( value: string, count: number, userChoice: boolean ) {
+        this.value = value;
+        this.count = count;
+        this.userChoice = userChoice;
+    }
+
+    @ApiProperty({example: '투표 선택지1'})
+    value: string;
+
+    @ApiProperty({example: 1})
+    count: number;
+
+    @ApiProperty({example: true})
+    userChoice: boolean;
+    
 
 }

--- a/src/question/question.dto.ts
+++ b/src/question/question.dto.ts
@@ -1,15 +1,19 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Length, IsNotEmpty, IsArray, ArrayMinSize, ArrayMaxSize } from 'class-validator';
+import { IsNotEmpty, IsArray, ArrayMinSize, ArrayMaxSize, ValidateIf } from 'class-validator';
 import { Question } from './question.entity';
 
 
 export class QuestionInCreate {
+    
+    @ApiProperty({example: false, default: false})
+    isOfficial: boolean;
 
     @ApiProperty({example: '질문 제목'})
     @IsNotEmpty()
     title: string;
 
     @ApiProperty({example: ['투표 선택지1', '투표 선택지2']})
+    @ValidateIf((obj) => !obj.isOfficial)
     @IsArray()
     @ArrayMinSize(1)
     @ArrayMaxSize(6)
@@ -18,8 +22,6 @@ export class QuestionInCreate {
     @ApiProperty({example: 'https://qfeed-s3.s3.ap-northeast-2.amazonaws.com/files/github.png'})
     backgroundImage: URL;
 
-    @ApiProperty({example: false, default: false})
-    isOfficial: boolean;
 
     @ApiProperty({example: false, default: false})
     isBlind: boolean;

--- a/src/question/question.entity.ts
+++ b/src/question/question.entity.ts
@@ -8,7 +8,7 @@ import {
     PrimaryGeneratedColumn,
     CreateDateColumn,
     UpdateDateColumn,
-    ManyToOne
+    ManyToOne,
  } from "typeorm";
 
 
@@ -41,7 +41,7 @@ export class Question extends TimeEntity {
     @Column({ default: false })
     isOfficial: boolean;
 
-    @Column({ default: false})
+    @Column({ default: false })
     isBlind: boolean;
 
 }

--- a/src/question/question.entity.ts
+++ b/src/question/question.entity.ts
@@ -1,5 +1,3 @@
-
-
 import { Account } from "src/account/account.entity";
 import { 
     BaseEntity, 
@@ -9,15 +7,16 @@ import {
     CreateDateColumn,
     UpdateDateColumn,
     ManyToOne,
+    OneToMany,
  } from "typeorm";
 
 
 export class TimeEntity extends BaseEntity {
     @CreateDateColumn()
-    created_at: Date;
+    createdAt: Date;
 
     @UpdateDateColumn()
-    updated_at: Date;
+    updatedAt: Date;
 }
 
 
@@ -44,14 +43,17 @@ export class Question extends TimeEntity {
     @Column({ default: false })
     isBlind: boolean;
 
+    @OneToMany(() => Choice, (choice) => choice.question)
+    choices: Choice[]
+
 }
 
-
+@Entity()
 export class Choice extends TimeEntity {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @ManyToOne(() => Question, (question) => question.id)
+    @ManyToOne(() => Question, (question) => question.choices)
     question: Question
 
     @ManyToOne(() => Account, (user) => user.id)

--- a/src/question/question.module.ts
+++ b/src/question/question.module.ts
@@ -2,11 +2,11 @@ import { Module } from '@nestjs/common';
 import { QuestionController } from './question.controller';
 import { QuestionService } from './question.service';
 import { TypeOrmExModule } from 'src/db/typeorm-ex.module';
-import { QuestionRepository } from './question.repository';
+import { ChoiceRepository, QuestionRepository } from './question.repository';
 
 @Module({
   imports: [
-    TypeOrmExModule.forCustomRepository([QuestionRepository]),
+    TypeOrmExModule.forCustomRepository([QuestionRepository, ChoiceRepository]),
   ],
   controllers: [QuestionController],
   providers: [QuestionService]

--- a/src/question/question.repository.ts
+++ b/src/question/question.repository.ts
@@ -1,8 +1,8 @@
 import { CustomRepository } from "src/db/typeorm-ex.decorator";
 import { InternalServerErrorException, NotFoundException } from "@nestjs/common";
-import { Question } from "./question.entity";
+import { Choice, Question } from "./question.entity";
 import { Repository } from "typeorm";
-import { QuestionInCreate } from "./question.dto";
+import { ChoiceResponse, QuestionInCreate } from "./question.dto";
 import { Account } from "src/account/account.entity";
 
 
@@ -27,7 +27,7 @@ export class QuestionRepository extends Repository<Question> {
             relations: ['owner'],
             skip: offset,
             take: limit,
-            order: { created_at: "DESC" }
+            order: { createdAt: "DESC" }
         });
         return questions;
     }
@@ -41,6 +41,50 @@ export class QuestionRepository extends Repository<Question> {
             return question;
         } else {
             throw new NotFoundException(`Can't find question with id: ${id}`);
+        }
+    }
+}
+
+
+@CustomRepository(Choice)
+export class ChoiceRepository extends Repository<Choice> {
+    async createChoice(user: Account, question: Question, value: string): Promise<Choice> {
+        try {
+            const choice = this.create({
+                user: user, question: question, value: value,
+            });
+            await this.save(choice);
+            return choice;
+        } catch (error) {
+            throw new InternalServerErrorException('create choice failed');
+        }
+    }
+
+    async fetchChoices(userId: number, questionId: number): Promise<ChoiceResponse[]> {
+        const query = this.createQueryBuilder('choice')
+            .select([
+                'choice.value as value', 
+                'COUNT(choice.id) as count', 
+                `SUM(CASE WHEN choice.user.id = ${userId} THEN 1 ELSE 0 END) > 0 as "userChoice"`
+            ])
+            .where( { "question":  { "id": questionId }} )
+            .groupBy('choice.value')
+
+        const result = await query.getRawMany();
+        return result.map((res) => new ChoiceResponse(res.value, res.count, res.userChoice));
+    }
+
+    async getChoiceById(questionId: number, id: number): Promise<Choice> {
+        const choice = await this.findOne({
+            where: {
+                "question":  { "id": questionId },
+                "id": id,
+            },
+        })
+        if(choice) {
+            return choice;
+        } else {
+            throw new NotFoundException(`Can't find choice with id: ${id}`);
         }
     }
 }

--- a/src/question/question.service.ts
+++ b/src/question/question.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { QuestionRepository } from './question.repository';
+import { ChoiceRepository, QuestionRepository } from './question.repository';
 import { Account } from 'src/account/account.entity';
-import { Question } from './question.entity';
-import { QuestionDto, QuestionInCreate, QuestionsResponse } from './question.dto';
+import { Choice, Question } from './question.entity';
+import { ChoiceResponse, QuestionDto, QuestionInCreate, QuestionsResponse } from './question.dto';
 
 
 @Injectable()
@@ -11,14 +11,17 @@ export class QuestionService {
     
     constructor( 
         @InjectRepository(QuestionRepository)
-        private questionRepository: QuestionRepository
+        private questionRepository: QuestionRepository,
+        
+        @InjectRepository(ChoiceRepository)
+        private choiceRepository: ChoiceRepository,
     ) {}
     
-    async create(user: Account, QuestionInCreate: QuestionInCreate): Promise<Question> {
+    async createQuestion(user: Account, QuestionInCreate: QuestionInCreate): Promise<Question> {
         return this.questionRepository.createQuestion(user, QuestionInCreate);
     }
 
-    async fetch(offset: number, limit: number): Promise<QuestionsResponse> {
+    async fetchQuestions(offset: number, limit: number): Promise<QuestionsResponse> {
         const questions = await this.questionRepository.fetchQuestions(offset, limit);
         const count = await this.questionRepository.count();
 
@@ -29,8 +32,21 @@ export class QuestionService {
     }
 
     async getQuestionById(id: number): Promise<Question> {
-        return this.questionRepository.getQuestionById(id);
+        const question = this.questionRepository.getQuestionById(id);
+        return question;
     }
 
+    async createChoice(user: Account, questionId: number, value: string): Promise<Choice> {
+        const question = await this.questionRepository.getQuestionById(questionId);
+        return this.choiceRepository.createChoice(user, question, value);
+    }
+
+    async fetchChoices(userId: number, questionId: number): Promise<ChoiceResponse[]> {
+        return this.choiceRepository.fetchChoices(userId, questionId);
+    }
+
+    async getChoiceById(questionId: number, id: number): Promise<Choice> {
+        return this.choiceRepository.getChoiceById(questionId, id);
+    }
 
 }


### PR DESCRIPTION
### Summary

- Choice API 를 추가합니다.

	- `GET` `POST` `/questions/{questionId}/choices `
	- `GET` `/questions/{questionId}/choices/{choiceId}`
	
-> qfeed 도메인에 맞춰 두가지 경우의 선택을 커버하도록 커스텀하였습니다. 상세설명은 구두로 진행하겠습니다.

