### PR TITLE
refactor: question pass, today api 스펙 변경

### DIFF
--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -51,6 +51,16 @@ export class AccountController {
         return new AccountDto(account);
     }
 
+    @ApiOperation({ summary: 'me update' })
+    @ApiResponse({ status: 200, description: 'Account info about myself', type: AccountDto })
+    @ApiBearerAuth('JWT')
+    @UseGuards(AuthGuard('jwt'))
+    @Patch('/me')
+    async updateAccount(@CurrentUser() account: Account, @Body() AccountInUpdate: AccountInUpdate): Promise<AccountDto> {
+        const updatedAccount = await this.accountService.update(account.id, AccountInUpdate);
+        return new AccountDto(updatedAccount);
+    }
+
     @Delete('me/hard-delete')
     @ApiBearerAuth('JWT')
     @UseGuards(AuthGuard('jwt'))
@@ -121,25 +131,6 @@ export class AccountController {
     ): Promise<UsersResponse> {
         return await this.accountService.fetch(keyword, offset, limit);
     }
-
-
-
-
-    
-
-
-    @ApiOperation({ summary: 'me update' })
-    @ApiResponse({ status: 200, description: 'Account info about myself', type: AccountDto })
-    @ApiBearerAuth('JWT')
-    @UseGuards(AuthGuard('jwt'))
-    @Patch('/me')
-    async updateAccount(@CurrentUser() account: Account, @Body() AccountInUpdate: AccountInUpdate): Promise<AccountDto> {
-        const updatedAccount = await this.accountService.update(account.id, AccountInUpdate);
-        return new AccountDto(updatedAccount);
-    }
-
-
-
 
     @ApiOperation({ summary: 'get user' })
     @ApiResponse({ status: 200, description: 'Account info about target user', type: AccountDto })

--- a/src/account/account.dto.ts
+++ b/src/account/account.dto.ts
@@ -84,9 +84,6 @@ export class AccountInUpdate {
 }
 
 
-
-
-
 export class checkNickname{
 
     constructor(nickname: string, available: boolean, message: string) {
@@ -104,6 +101,7 @@ export class checkNickname{
     @ApiProperty({example: '사용 가능한 닉네임 입니다.'})
     message: string;
 }
+
 
 export class AccountDto {
     constructor(account: Account) {
@@ -212,6 +210,7 @@ export class UsersResponse {
     data: UserDto[];
 
 }
+
 export class TokenDto {
 
     constructor(token: string, expireTime: Date) {

--- a/src/question/question.controller.ts
+++ b/src/question/question.controller.ts
@@ -26,26 +26,27 @@ export class QuestionController {
     }
 
     @ApiOperation({ summary: 'get UserQset' })
-    @ApiResponse({ status: 200, type: UserQsetDto })
+    @ApiResponse({ status: 200, type: [UserQsetDto] })
     @ApiBearerAuth('JWT')
     @UseGuards(AuthGuard('jwt'))
-    @Get('/q-set')
+    @Get('/q-set/today')
     async getUserQset(
         @CurrentUser() user: Account,
     ) {
-        const userQset = await this.questionService.getCurrentUserQset(user);
-        return new UserQsetDto(userQset);
+        const todayUserQsets = await this.questionService.getTodayUserQset(user);
+        return todayUserQsets.map((userQset) => new UserQsetDto(userQset));
     }
 
     @ApiOperation({ summary: 'Pass UserQ' })
     @ApiResponse({ status: 200, type: UserQsetDto })
     @ApiBearerAuth('JWT')
     @UseGuards(AuthGuard('jwt'))
-    @Patch('/q-set/pass')
-    async passUseQ(
+    @Patch('/q-set/:userQsetId/pass')
+    async passUserQ(
         @CurrentUser() user: Account,
+        @Param('userQsetId') userQsetId: number,
     ) {
-        const userQset = await this.questionService.passUseQ(user);
+        const userQset = await this.questionService.passUserQ(user, userQsetId);
         return new UserQsetDto(userQset);
     }
 

--- a/src/question/question.repository.ts
+++ b/src/question/question.repository.ts
@@ -172,7 +172,7 @@ export class UserQsetRepository extends Repository<UserQset> {
         return userQsets
     }
     
-    async getLastUserQsetBy(user: Account): Promise<UserQset> {
+    async getLastUserQset(user: Account): Promise<UserQset> {
         const UserQset = await this.findOne({
             relations: ['user', 'Qset'],
             where: {

--- a/src/question/question.service.ts
+++ b/src/question/question.service.ts
@@ -83,14 +83,21 @@ export class QuestionService {
 
     async getTodayUserQset(user: Account): Promise<UserQset[]> {
         const todayUserQsets = await this.userQsetRepository.getTodayUserQsets(user);
+        if (todayUserQsets.length == 0) {
+            const lastUserQset = await this.userQsetRepository.getLastUserQset(user);
+            return [lastUserQset];
+        }
         return todayUserQsets;
     }
 
     async createUserQset(user: Account) {
         // TODO: transaction 으로 묶기 or outer join with history 고려
         const todayUserQsets = await this.userQsetRepository.getTodayUserQsets(user);
-        if (todayUserQsets.length >= 2) {
+        if (todayUserQsets.length == 2) {
             throw new BadRequestException(`already created 2 userQset today`);
+        }
+        if (todayUserQsets.length == 1 && !todayUserQsets[0].isDone) {
+            throw new BadRequestException(`exist not done userQset`);
         }
         const userQsetList = await this.userQsetRepository.fetchDoneUserQset(user);
         const excludedQsetIds = userQsetList.map((userQset: UserQset) => userQset.Qset.id);


### PR DESCRIPTION
### Summary

---

**- `Get` /q-set API 변경**
  
    변경된 url : `/q-set/today` 
    
    -> 오늘 진행한 Q-set 리스트를 최신순으로 리턴합니다. 오늘 진행한 것이 없을 경우 가장 최신 Q-set을 리턴합니다.

    
   **Case**
    1. 2개 리턴 and 최근 Q-set.isDone = true
        -> 하루 할당량 끝
    2. (1개,2개) 리턴 and 최근 Q-set.isDone = false
        -> 최근 Q-set 진행
    3. 1개 리턴 and 최근 Q-set.isDone = true
        -> 최근 Q-set endAt 확인하여 남은 시간 표시
    4. 0개 리턴
        -> `Post` /q-set  을 사용하여 생성


--- 


**- `Patch` /q-set/pass API 변경**

    변경된 url: `/q-set/{userQsetId}/pass` 
    
    -> 해당 id 값을 가진 Q-set 이 진행중인 것을 확인하고, 해당 cursor의 질문을 패스합니다.