### PR TITLE
feat: Official-Q choice 구현

### DIFF
--- a/src/question/question.controller.ts
+++ b/src/question/question.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Get, Post, Patch, Query, UseGuards, Param } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { QuestionService } from './question.service';
-import { QuestionsResponse, QuestionDto, QuestionInCreate, ChoiceInCreate, ChoiceDto, UserQsetDto } from './question.dto';
+import { QuestionsResponse, QuestionDto, QuestionInCreate, ChoiceInCreate, ChoiceDto, UserQsetDto, ChoiceInUserQ } from './question.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { CurrentUser } from 'src/account/get-user.decorator';
 import { Account } from 'src/account/account.entity';
@@ -49,6 +49,21 @@ export class QuestionController {
         const userQset = await this.questionService.passUserQ(user, userQsetId);
         return new UserQsetDto(userQset);
     }
+
+    @ApiOperation({ summary: 'choice in Qset' })
+    @ApiResponse({ status: 201, type: UserQsetDto })
+    @ApiBearerAuth('JWT')
+    @UseGuards(AuthGuard('jwt'))
+    @Post('/q-set/:userQsetId/choice')
+    async choiceUserQ(
+        @CurrentUser() user: Account,
+        @Param('userQsetId') userQsetId: number,
+        @Body() choiceInUserQ: ChoiceInUserQ
+    ) {
+        const userQset = await this.questionService.choiceUserQ(user, userQsetId, choiceInUserQ);
+        return new UserQsetDto(userQset);
+    }
+
 
     @ApiOperation({ summary: 'create question' })
     @ApiResponse({ status: 201,  type: QuestionDto })

--- a/src/question/question.dto.ts
+++ b/src/question/question.dto.ts
@@ -39,6 +39,18 @@ export class ChoiceInCreate {
 
 }
 
+export class ChoiceInUserQ {
+    
+        @ApiProperty({example: 1})
+        @IsNotEmpty()
+        targetUserId: number;
+
+        @ApiProperty({example: '투표한 친구에게 한마디 작성하세요'})
+        @IsNotEmpty()
+        value: string;
+    
+}
+
 
 export class ViewHistoryDto {
         

--- a/src/question/question.module.ts
+++ b/src/question/question.module.ts
@@ -3,10 +3,12 @@ import { QuestionController } from './question.controller';
 import { QuestionService } from './question.service';
 import { TypeOrmExModule } from 'src/db/typeorm-ex.module';
 import { ChoiceRepository, ViewHistoryRepository, QuestionRepository, QsetRepository, UserQsetRepository } from './question.repository';
+import { AccountRepository } from 'src/account/account.repository';
 
 @Module({
   imports: [
     TypeOrmExModule.forCustomRepository([
+      AccountRepository,
       QuestionRepository,
       ChoiceRepository,
       ViewHistoryRepository,

--- a/src/question/question.repository.ts
+++ b/src/question/question.repository.ts
@@ -19,6 +19,9 @@ export class QuestionRepository extends Repository<Question> {
             await this.save(question);
             return question;
         } catch (error) {
+            if (error.code === '23505') {
+                throw new ConflictException(`already create this title in user [${QuestionInCreate.title}]`);
+            }
             throw new InternalServerErrorException('create question failed');
         }
     }
@@ -60,7 +63,7 @@ export class QuestionRepository extends Repository<Question> {
         }
     }
 
-    async getOrCreateUserQ(targetUser: Account, title: string): Promise<Question> {
+    async getOrCreateOfficialQ(targetUser: Account, title: string): Promise<Question> {
         const question = await this.findOne({
             where: { 
                 owner : { id: targetUser.id },

--- a/src/question/question.service.ts
+++ b/src/question/question.service.ts
@@ -1,16 +1,23 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
+import { Injectable, BadRequestException, ForbiddenException, ConflictException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { EntityManager } from 'typeorm';
 import { ChoiceRepository, ViewHistoryRepository, QuestionRepository, QsetRepository, UserQsetRepository} from './question.repository';
 import { Account } from 'src/account/account.entity';
 import { Choice, UserQset, Question, ViewHistory } from './question.entity';
-import { QuestionFetchDto, QuestionInCreate, QuestionsResponse } from './question.dto';
 import { Qtype } from './question.enum';
+import { ChoiceInUserQ, QuestionFetchDto, QuestionInCreate, QuestionsResponse } from './question.dto';
+import { AccountRepository } from 'src/account/account.repository';
 
 
 @Injectable()
 export class QuestionService {
     
     constructor( 
+        private readonly entityManager: EntityManager,
+        
+        @InjectRepository(AccountRepository)
+        private accountRepository: AccountRepository,
+
         @InjectRepository(QuestionRepository)
         private questionRepository: QuestionRepository,
         
@@ -60,6 +67,8 @@ export class QuestionService {
         return question;
     }
 
+    
+
     async createChoice(user: Account, questionId: number, value: string): Promise<Choice> {
         const question = await this.questionRepository.getQuestionById(questionId);
         if (question.owner.id === user.id) {
@@ -91,13 +100,12 @@ export class QuestionService {
     }
 
     async createUserQset(user: Account) {
-        // TODO: transaction 으로 묶기 or outer join with history 고려
         const todayUserQsets = await this.userQsetRepository.getTodayUserQsets(user);
         if (todayUserQsets.length == 2) {
             throw new BadRequestException(`already created 2 userQset today`);
         }
         if (todayUserQsets.length == 1 && !todayUserQsets[0].isDone) {
-            throw new BadRequestException(`exist not done userQset`);
+            throw new BadRequestException(`exist running userQset`);
         }
         const userQsetList = await this.userQsetRepository.fetchDoneUserQset(user);
         const excludedQsetIds = userQsetList.map((userQset: UserQset) => userQset.Qset.id);
@@ -109,7 +117,7 @@ export class QuestionService {
     async passUserQ(user: Account, userQsetId: number): Promise<UserQset> {
         const CurrentUserQset = await this.userQsetRepository.getUserQset(userQsetId);
         if (CurrentUserQset.user.id !== user.id) {
-            throw new BadRequestException(`Can't pass other user's qset`);
+            throw new ForbiddenException(`Can't pass other user's qset`);
         }
         if (CurrentUserQset.isDone) {
             throw new BadRequestException(`already done`);
@@ -121,5 +129,39 @@ export class QuestionService {
         return await this.userQsetRepository.save(CurrentUserQset);
         
     }
+
+    async choiceUserQ(user: Account, userQsetId: number, choiceInUserQ: ChoiceInUserQ): Promise<UserQset> {
+    
+        if (choiceInUserQ.targetUserId === user.id) {
+            throw new BadRequestException(`Can't choice yourself`)
+        }
+        const CurrentUserQset = await this.userQsetRepository.getUserQset(userQsetId);
+        if (CurrentUserQset.user.id !== user.id) {
+            throw new ForbiddenException(`Can't choice other user's qset`);
+        }
+        if (CurrentUserQset.isDone) {
+            throw new BadRequestException(`already done`);
+        }
+
+        const title = CurrentUserQset.Qset.QList[CurrentUserQset.cursor];
+        const targetUser = await this.accountRepository.getAccountById(choiceInUserQ.targetUserId);
+        let nextUserQset: UserQset;
+
+        try{
+            await this.entityManager.transaction(async transactionalEntityManager => {
+                const question = await this.questionRepository.getOrCreateOfficialQ(targetUser, title);
+                await this.choiceRepository.createChoice(user, question, choiceInUserQ.value);
+                nextUserQset = await this.passUserQ(user, userQsetId);
+                await transactionalEntityManager.save(Question);
+                await transactionalEntityManager.save(Choice);
+                await transactionalEntityManager.save(UserQset);
+            });
+        } catch (error) {
+            throw new ConflictException(`[TRANSACTION] choice failed ]`);
+        }
+        return nextUserQset;
+
+    }        
+
 
 }

--- a/src/question/question.service.ts
+++ b/src/question/question.service.ts
@@ -150,14 +150,16 @@ export class QuestionService {
         try{
             await this.entityManager.transaction(async transactionalEntityManager => {
                 const question = await this.questionRepository.getOrCreateOfficialQ(targetUser, title);
-                await this.choiceRepository.createChoice(user, question, choiceInUserQ.value);
+                const choice = await this.choiceRepository.createChoice(user, question, choiceInUserQ.value);
                 nextUserQset = await this.passUserQ(user, userQsetId);
-                await transactionalEntityManager.save(Question);
-                await transactionalEntityManager.save(Choice);
-                await transactionalEntityManager.save(UserQset);
+                await transactionalEntityManager.save(question);
+                await transactionalEntityManager.save(choice);
+                await transactionalEntityManager.save(nextUserQset);
             });
         } catch (error) {
-            throw new ConflictException(`[TRANSACTION] choice failed ]`);
+            if (error instanceof ConflictException)
+                throw error;
+            throw new ConflictException(`[TRANSACTION] choice failed`);
         }
         return nextUserQset;
 


### PR DESCRIPTION
### Summary

- `/questions/q-set/{userQsetId}/choice` API 추가

	-> Official-Q 진행중에 choice 하는 API 를 추가합니다.
	-> 선택받은 유저(targetUserId) 와 같이 보내는 한마디 (value) 를 key 로 하여 요청을 보냅니다.

