### PR TITLE
feat: Block API 구현

### DIFF
--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -155,31 +155,29 @@ export class AccountController {
     }
 
     @ApiOperation({ summary: 'follow user' })
-    @ApiResponse({ status: 201, description: 'follow user', type: UserDto })
+    @ApiResponse({ status: 201, description: 'follow user'})
     @ApiBearerAuth('JWT')
     @UseGuards(AuthGuard('jwt'))
     @Post('/:targetUserId/follow')
     async followUser(
         @CurrentUser() user: Account,
         @Param('targetUserId', ParseIntPipe) targetUserId: number
-    ): Promise<UserDto> {
-        const targetUser = await this.accountService.getAccountById(targetUserId);
-        await this.accountService.followUser(user, targetUser);
-        return new UserDto(targetUser);
+    ): Promise<any> {
+        await this.accountService.followUser(user, targetUserId);
+        return { message: "success" }
     }
 
     @ApiOperation({ summary: 'unfollow user' })
-    @ApiResponse({ status: 200, description: 'unfollow user', type: UserDto })
+    @ApiResponse({ status: 200, description: 'unfollow user' })
     @ApiBearerAuth('JWT')
     @UseGuards(AuthGuard('jwt'))
     @Delete('/:targetUserId/unfollow')
     async unfollowUser(
         @CurrentUser() user: Account,
         @Param('targetUserId', ParseIntPipe) targetUserId: number
-    ): Promise<UserDto> {
-        const targetUser = await this.accountService.getAccountById(targetUserId);
-        await this.accountService.unfollowUser(user, targetUser);
-        return new UserDto(targetUser);
+    ): Promise<any> {
+        await this.accountService.unfollowUser(user, targetUserId);
+        return { message: "success" }
     }
 
     @ApiOperation({ summary: 'block user' })

--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -182,4 +182,30 @@ export class AccountController {
         return new UserDto(targetUser);
     }
 
+    @ApiOperation({ summary: 'block user' })
+    @ApiResponse({ status: 201, description: 'block user' })
+    @ApiBearerAuth('JWT')
+    @UseGuards(AuthGuard('jwt'))
+    @Post('/:targetUserId/Block')
+    async BlockUser(
+        @CurrentUser() user: Account,
+        @Param('targetUserId', ParseIntPipe) targetUserId: number
+    ): Promise<any> {
+        await this.accountService.blockUser(user, targetUserId);
+        return { "message": "success" }
+    }
+
+    @ApiOperation({ summary: 'unBlock user' })
+    @ApiResponse({ status: 200, description: 'unBlock user' })
+    @ApiBearerAuth('JWT')
+    @UseGuards(AuthGuard('jwt'))
+    @Delete('/:targetUserId/unblock')
+    async unBlockUser(
+        @CurrentUser() user: Account,
+        @Param('targetUserId', ParseIntPipe) targetUserId: number
+    ): Promise<any> {
+        await this.accountService.unblockUser(user, targetUserId);
+        return { "message": "success" }
+    }
+
 }

--- a/src/account/account.dto.ts
+++ b/src/account/account.dto.ts
@@ -207,6 +207,7 @@ export class UserProfileDto {
         this.grade = account.grade;
         this.gender = account.gender;
         this.isFollowing = account.followers.some((follow) => follow.user.id === currentUserId);
+        this.isBlocking = account.blockers.some((block) => block.user.id === currentUserId);
     }
 
     @ApiProperty({example: 1})
@@ -232,6 +233,9 @@ export class UserProfileDto {
 
     @ApiProperty({example: true})
     isFollowing: boolean;
+
+    @ApiProperty({example: false})
+    isBlocking: boolean;
 }
 
 

--- a/src/account/account.entity.ts
+++ b/src/account/account.entity.ts
@@ -84,3 +84,18 @@ export class Follow extends TimeEntity {
     targetUser: Account;
 
 }
+
+@Entity()
+@Unique(['user', 'targetUser'])
+export class Block extends TimeEntity {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(() => Account, (user) => user.followings, { onDelete: 'CASCADE' })
+    user: Account;
+
+    @ManyToOne(() => Account, (user) => user.followers, { onDelete: 'CASCADE' })
+    targetUser: Account;
+
+}
+

--- a/src/account/account.entity.ts
+++ b/src/account/account.entity.ts
@@ -68,6 +68,13 @@ export class Account extends TimeEntity {
     @OneToMany(() => Follow, (follow) => follow.targetUser)
     followers: Follow[]
 
+    @OneToMany(() => Block, (block) => block.user)
+    blockings: Block[]
+
+    @OneToMany(() => Block, (block) => block.targetUser)
+    blockers: Block[]
+
+
 }
 
 
@@ -91,10 +98,10 @@ export class Block extends TimeEntity {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @ManyToOne(() => Account, (user) => user.followings, { onDelete: 'CASCADE' })
+    @ManyToOne(() => Account, (user) => user.blockings, { onDelete: 'CASCADE' })
     user: Account;
 
-    @ManyToOne(() => Account, (user) => user.followers, { onDelete: 'CASCADE' })
+    @ManyToOne(() => Account, (user) => user.blockers, { onDelete: 'CASCADE' })
     targetUser: Account;
 
 }

--- a/src/account/account.module.ts
+++ b/src/account/account.module.ts
@@ -4,19 +4,19 @@ import { PassportModule } from '@nestjs/passport';
 import { AccountController } from './account.controller';
 import { AccountService } from './account.service';
 import { TypeOrmExModule } from 'src/db/typeorm-ex.module';
-import { AccountRepository, FollowRepository } from './account.repository';
+import { AccountRepository, BlockRepository, FollowRepository } from './account.repository';
 import { JwtStrategy } from './jwt.strategy';
 import { HttpModule } from '@nestjs/axios';
 
 @Module({
   exports: [AccountService, JwtStrategy, PassportModule],
   imports: [
-    TypeOrmExModule.forCustomRepository([AccountRepository, FollowRepository]),
+    TypeOrmExModule.forCustomRepository([AccountRepository, FollowRepository, BlockRepository]),
     PassportModule.register({ defaultStrategy: 'jwt'}),
     JwtModule.register({
       secret: process.env.SECRET_KEY,
       signOptions:{
-        expiresIn: 60 * 60 * 24
+        expiresIn: 60 * 60 * 24 * 30,
       }
     }),
     HttpModule.registerAsync({

--- a/src/account/account.repository.ts
+++ b/src/account/account.repository.ts
@@ -42,7 +42,7 @@ export class AccountRepository extends Repository<Account> {
 
     async getAccountById(id: number): Promise<Account> {
         const account = await this.findOne({
-            relations: ["followers.user",],
+            relations: ["followers.user", "blockers.user"],
             where: { id : id }
         })
         if(account) {
@@ -70,7 +70,7 @@ export class AccountRepository extends Repository<Account> {
 
     async fetchAccounts(keyword: string, offset: number, limit: number): Promise<Account[]> {
         const accounts = await this.find({
-            relations: ["followers.user",],
+            relations: ["followers.user", "blockers.user"],
             where: [
                 { name : Like(`%${keyword}%`) },
                 { nickname: Like(`%${keyword}%`) }
@@ -208,7 +208,7 @@ export class BlockRepository extends Repository<Block> {
         return await this.save(block);
     }
 
-    async fetchBlocking(user: Account,  offset: number, limit: number): Promise<Block[]> {
+    async fetchBlockings(user: Account,  offset: number, limit: number): Promise<Block[]> {
         const blocks = await this.find({
             where: { user: { id : user.id } },
             skip: offset,

--- a/src/account/account.repository.ts
+++ b/src/account/account.repository.ts
@@ -120,21 +120,11 @@ export class AccountRepository extends Repository<Account> {
 @CustomRepository(Follow)
 export class FollowRepository extends Repository<Follow> {
 
-    async createFollow(user: Account, targetUser: Account): Promise<Follow> {
-        if (user.id === targetUser.id) {
-            throw new ConflictException('can not follow myself');
-        }
-        try {
-            const Follow = this.create({
-                user: user, targetUser: targetUser
-            });
-            return await this.save(Follow);
-        } catch (error) {
-            if (error.code === '23505') {
-                return await this.getFollow(user, targetUser)
-            }
-            throw new InternalServerErrorException('create follow failed');
-        }
+    async createFollow(user: Account, targetUserId: number): Promise<Follow> {
+        const Follow = this.create({
+            user: user, targetUser: {id: targetUserId}
+        });
+        return await this.save(Follow);
     }
 
     async fetchFollowings(user: Account, keyword: string, offset: number, limit: number): Promise<Follow[]> {
@@ -187,10 +177,10 @@ export class FollowRepository extends Repository<Follow> {
         }
     }
 
-    async deleteFollow(user: Account, targetUser: Account): Promise<void> {
+    async deleteFollow(user: Account, targetUserId: number): Promise<void> {
         await this.delete({
             user: { id: user.id },
-            targetUser: { id: targetUser.id }
+            targetUser: { id: targetUserId }
         })
     }
 

--- a/src/account/account.repository.ts
+++ b/src/account/account.repository.ts
@@ -1,7 +1,7 @@
-import { In, IsNull, Like, Not, QueryFailedError, Repository } from "typeorm";
+import { In, IsNull, Like, Not, Repository } from "typeorm";
 import * as bcrypt from 'bcryptjs';
 import { ConflictException, InternalServerErrorException, NotFoundException } from "@nestjs/common";
-import { Account, Follow } from "./account.entity";
+import { Account, Block, Follow } from "./account.entity";
 import { AccountInSign, AccountInUpdate } from "./account.dto";
 import { CustomRepository } from "src/db/typeorm-ex.decorator";
 
@@ -194,5 +194,45 @@ export class FollowRepository extends Repository<Follow> {
         })
     }
 
+
+}
+
+
+@CustomRepository(Block)
+export class BlockRepository extends Repository<Block> {
+
+    async createBlock(user: Account, targetUserId: number): Promise<Block> {
+        const block = this.create({
+            user: user, targetUser: {id: targetUserId}
+        });
+        return await this.save(block);
+    }
+
+    async fetchBlocking(user: Account,  offset: number, limit: number): Promise<Block[]> {
+        const blocks = await this.find({
+            where: { user: { id : user.id } },
+            skip: offset,
+            take: limit,
+        })
+        return blocks;
+    }
+
+    async fetchBlocked(user: Account, offset: number, limit: number): Promise<Block[]> {
+        const blocks = await this.find({
+            where: {
+                targetUser:  { id: user.id },
+            },
+            skip: offset,
+            take: limit,
+        })
+        return blocks;
+    }
+
+    async deleteBlock(user: Account, targetUserId: number): Promise<void> {
+        await this.delete({
+            user: { id: user.id },
+            targetUser: { id: targetUserId }
+        })
+    }
 
 }

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -270,7 +270,8 @@ export class AccountService {
             throw new BadRequestException("자기 자신은 차단할 수 없습니다.");
         }
         try {
-            // TODO: await this.followRepository.deleteFollow(user, targetUserId);
+            // TODO: transaction 묶기
+            await this.followRepository.deleteFollow(user, targetUserId);
             await this.blockRepository.createBlock(user, targetUserId);
         } catch (error) {
             if (error.code === '23505') throw new ConflictException("이미 차단한 사용자입니다.");

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException, BadRequestException } from '@nestjs/common';
+import { Injectable, UnauthorizedException, BadRequestException, InternalServerErrorException, ConflictException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt'
 import { HttpService } from '@nestjs/axios';
 
@@ -6,10 +6,10 @@ import { InjectRepository } from '@nestjs/typeorm';
 import * as bcrypt from 'bcryptjs';
 
 import { AccountInSign, AccountInUpdate, UsersResponse, TokenDto, UserDto, checkNickname, UserProfileDto, UsersProfileResponse } from './account.dto';
-import { AccountRepository, FollowRepository } from './account.repository';
+import { AccountRepository, BlockRepository, FollowRepository } from './account.repository';
 import { AxiosRequestConfig } from 'axios';
 import { map, lastValueFrom } from 'rxjs';
-import { Account, Follow } from './account.entity';
+import { Account, Block, Follow } from './account.entity';
 import { In, IsNull, Like, Not } from 'typeorm';
 
 
@@ -22,6 +22,9 @@ export class AccountService {
         
         @InjectRepository(FollowRepository)
         private followRepository: FollowRepository,
+
+        @InjectRepository(BlockRepository)
+        private blockRepository: BlockRepository,
 
         private jwtService: JwtService,
         private readonly httpService: HttpService
@@ -86,7 +89,6 @@ export class AccountService {
 
     async fetch(user: Account, keyword: string, offset: number, limit: number): Promise<UsersProfileResponse> {
         const accounts = await this.accountRepository.fetchAccounts(keyword, offset, limit);
-        console.log(accounts)
         const count = await this.accountRepository.count({
             where: [
                 { name : Like(`%${keyword}%`) },
@@ -243,5 +245,33 @@ export class AccountService {
             unfollowingUsers.map((account: Account) => new UserDto(account)),
             count
         );
-    }  
+    }
+
+
+    async blockUser(user: Account, targetUserId: number): Promise<void> {
+        if (user.id === targetUserId) {
+            throw new BadRequestException("자기 자신은 차단할 수 없습니다.");
+        }
+        try {
+            await this.blockRepository.createBlock(user, targetUserId);
+        } catch (error) {
+            if (error.code === '23505') throw new ConflictException("이미 차단한 사용자입니다.");
+            else if (error.code === '23503') throw new BadRequestException("존재하지 않는 사용자입니다.");
+            else throw new InternalServerErrorException("차단에 실패했습니다.");
+        }
+    }
+
+    async unblockUser(user: Account, targetUserId: number): Promise<void> {
+        if (user.id === targetUserId) {
+            throw new BadRequestException("자기 자신은 차단해제할 수 없습니다.");
+        }
+        try {
+            await this.blockRepository.deleteBlock(user, targetUserId);
+        } catch (error) {
+            throw new InternalServerErrorException("차단해제에 실패했습니다.");
+        }
+    }
+
+
+
 }


### PR DESCRIPTION
### Summary

- jwt 유효기간 연장
- 차단 기능 구현

추가 API
- POST /account/{targetUserId}/Block
- Delete /account/{targetUserId}/unBlock

수정 API

- POST /account/{targetUserId}/follow
- Delete /account/{targetUserId}/unfollow

기존 리턴값: 
{
  "id": 1,
  "name": "김피드",
  "nickname": "김피드",
  "profileImage": "https://blog.kakaocdn.net/dn/KdDOI/btrmGgNlqab/qlMwwXNvHSbjN0kFeIoVuK/img.jpg",
  "schoolName": "큐피대학교",
  "grade": "20학번",
  "gender": "남"
}

변경 리턴값: { "message": "success" } 

