### PR TITLE
refactor: chatroom get or create 로 변경

### DIFF
--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException, BadRequestException, InternalServerErrorException, ConflictException } from '@nestjs/common';
+import { Injectable, UnauthorizedException, BadRequestException, InternalServerErrorException, ConflictException, NotFoundException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt'
 import { HttpService } from '@nestjs/axios';
 
@@ -9,7 +9,7 @@ import { AccountInSign, AccountInUpdate, UsersResponse, TokenDto, UserDto, check
 import { AccountRepository, BlockRepository, FollowRepository } from './account.repository';
 import { AxiosRequestConfig } from 'axios';
 import { map, lastValueFrom } from 'rxjs';
-import { Account, Block, Follow } from './account.entity';
+import { Account, Follow } from './account.entity';
 import { In, IsNull, Like, Not } from 'typeorm';
 
 
@@ -198,7 +198,7 @@ export class AccountService {
             await this.followRepository.createFollow(user, targetUserId);
         } catch (error) {
             if (error.code === '23505') throw new ConflictException("이미 팔로우 한 사용자입니다.");
-            else if (error.code === '23503') throw new BadRequestException("존재하지 않는 사용자입니다.");
+            else if (error.code === '23503') throw new NotFoundException("존재하지 않는 사용자입니다.");
             else throw new InternalServerErrorException("팔로우에 실패했습니다.");
         }
     }
@@ -275,7 +275,7 @@ export class AccountService {
             await this.blockRepository.createBlock(user, targetUserId);
         } catch (error) {
             if (error.code === '23505') throw new ConflictException("이미 차단한 사용자입니다.");
-            else if (error.code === '23503') throw new BadRequestException("존재하지 않는 사용자입니다.");
+            else if (error.code === '23503') throw new NotFoundException("존재하지 않는 사용자입니다.");
             else throw new InternalServerErrorException("차단에 실패했습니다.");
         }
     }

--- a/src/chatroom/chatroom.controller.ts
+++ b/src/chatroom/chatroom.controller.ts
@@ -14,16 +14,16 @@ export class ChatroomController {
         
     constructor(private readonly chatroomService: ChatroomService) {}
 
-    @ApiOperation({ summary: 'create chatroom' })
+    @ApiOperation({ summary: 'get or create chatroom' })
     @ApiResponse({ status: 201,  type: ChatroomDto })
     @ApiBearerAuth('JWT')
     @UseGuards(AuthGuard('jwt'))
     @Post('/')
-    async createChatroom(
+    async getOrCreateChatroom(
         @CurrentUser() user: Account,
         @Body() chatroomInCreate: ChatroomInCreate,
     ): Promise<ChatroomDto> {
-        const chatroom = await this.chatroomService.createChatroom(user.id, chatroomInCreate.targetUserId, chatroomInCreate.title);
+        const chatroom = await this.chatroomService.getOrCreateChatroom(user.id, chatroomInCreate.targetUserId, chatroomInCreate.title);
         return new ChatroomDto(chatroom);
     }
 

--- a/src/chatroom/chatroom.repository.ts
+++ b/src/chatroom/chatroom.repository.ts
@@ -10,19 +10,13 @@ import { Account } from "src/account/account.entity";
 export class ChatroomRepository extends Repository<Chatroom> {
     
     async createChatroom(ownerId: number, targetUserId: number, title: string): Promise<Chatroom> {
-        try {
-            const chatroom = this.create({
-                owner: { id: ownerId },
-                targetUser: { id: targetUserId },
-                title: title,
-            });
-            await this.save(chatroom);
-            return chatroom;
-        } catch (error) {
-            if (error.code === '23503') {
-                throw new NotFoundException(`user [${targetUserId}] not found`);
-            }
-        }
+        const chatroom = this.create({
+            owner: { id: ownerId },
+            targetUser: { id: targetUserId },
+            title: title,
+        });
+        await this.save(chatroom);
+        return chatroom;
     }
 
     async fetchChatrooms(userId: number, offset: number, limit: number): Promise<Chatroom[]> {
@@ -44,11 +38,21 @@ export class ChatroomRepository extends Repository<Chatroom> {
             relations: ['targetUser', 'owner'],
             where: { id: id }
         })
-        if(chatroom) {
-            return chatroom;
-        }
-        throw new NotFoundException(`Can't find chatroom with id ${id}`);
+        return chatroom;
     }
+
+    async getChatroomByTitle(ownerId: number, targetUserId: number, title: string): Promise<Chatroom> {
+        const chatroom = await this.findOne({
+            relations: ['targetUser', 'owner'],
+            where: { 
+                owner: { id: ownerId },
+                targetUser: { id: targetUserId },
+                title: title,
+            }
+        })
+        return chatroom;
+    }
+        
 
 }
 


### PR DESCRIPTION
### Summary

기존에 사용한 POST /chatrooms API 의 내부 구현을 조정합니다.
변경전: 생성
변경후: get 하고 없으면 생성, 있으면 반환

-> 같은 title 과 targetUser 에 대해서는 하나의 채팅방만 갖습니다.

