### PR TITLE
refactor: fetch user 차단 관련 수정

### DIFF
--- a/src/question/question.dto.ts
+++ b/src/question/question.dto.ts
@@ -3,7 +3,6 @@ import { IsNotEmpty, IsArray, ArrayMinSize, ArrayMaxSize, ValidateIf, IsEnum, Is
 import { Choice, Question, UserQset, ViewHistory } from './question.entity';
 import { UserDto, UserFetchDto } from 'src/account/account.dto';
 import { Qtype } from './question.enum';
-import { raw } from 'express';
 
 
 export class QuestionInCreate {

--- a/src/question/question.repository.ts
+++ b/src/question/question.repository.ts
@@ -49,7 +49,6 @@ export class QuestionRepository extends Repository<Question> {
             .leftJoin('question.owner', 'owner')
             .groupBy('question.id')
             .addGroupBy('owner.id')
-            .orderBy('"isViewed"')
             .addOrderBy('"isChoiced"')
             .addOrderBy(`"${orderBy}"`, 'DESC')
             .where('question.ownerId IN (:...followingUserIds)', { followingUserIds })

--- a/src/question/question.repository.ts
+++ b/src/question/question.repository.ts
@@ -27,6 +27,9 @@ export class QuestionRepository extends Repository<Question> {
     }
 
     async fetchQuestionsByQuery(currentUser: Account, followingUserIds: number[] , qtype: Qtype, orderBy: OrderBy, offset: number, limit: number): Promise<[number, any]>{
+        if (followingUserIds.length === 0) {
+            return [0, []]
+        }
         const query = this.createQueryBuilder('question')
             .select([
                 'question.id as "id"',
@@ -55,8 +58,8 @@ export class QuestionRepository extends Repository<Question> {
             .andWhere('question.isBlind = false')
             .andWhere(`question.Qtype = '${qtype}'`)
 
-            const questions = await query.limit(limit).offset(offset).getRawMany();
-            const count = await query.getCount();
+        const questions = await query.limit(limit).offset(offset).getRawMany();
+        const count = await query.getCount();
         return [count, questions]
     }
 

--- a/src/question/question.service.ts
+++ b/src/question/question.service.ts
@@ -41,12 +41,12 @@ export class QuestionService {
 
     async fetchFollowingQuestions(user: Account, qtype: Qtype, orderBy: OrderBy, offset: number, limit: number): Promise<QuestionFetchByQueryResponse> {
         const currentUser = await this.accountRepository.findOne({
-            relations: ["followings", "followings.targetUser", "blockers", "blockers.targetUser"], 
+            relations: ["followings.targetUser", "blockers.user"], 
             where: { id: user.id }
         })
         const followingUserIds = currentUser.followings.map( (follow: Follow) => follow.targetUser.id )
         const filteredFollowingUserIds = followingUserIds.filter( (userId) => !currentUser.blockers.some((block) => block.user.id === userId) );
-        const [count, questions] = await this.questionRepository.fetchQuestionsByQuery(user,filteredFollowingUserIds, qtype, orderBy, offset, limit);
+        const [count, questions] = await this.questionRepository.fetchQuestionsByQuery(user, filteredFollowingUserIds, qtype, orderBy, offset, limit);
         return new QuestionFetchByQueryResponse(count, questions.map((row: any) => new QuestionFetchByQueryDto(row)))
     }
 

--- a/src/question/question.service.ts
+++ b/src/question/question.service.ts
@@ -36,6 +36,10 @@ export class QuestionService {
     ) {}
     
     async createQuestion(user: Account, QuestionInCreate: QuestionInCreate): Promise<Question> {
+        if (QuestionInCreate.choiceList) {
+            const setList = new Set(QuestionInCreate.choiceList)
+            if (QuestionInCreate.choiceList.length !== setList.size ) new BadRequestException(`items of choiceList is duplicated`)
+        }
         return await this.questionRepository.createQuestion(user, QuestionInCreate);
     }
 

--- a/src/question/question.service.ts
+++ b/src/question/question.service.ts
@@ -38,7 +38,8 @@ export class QuestionService {
     async createQuestion(user: Account, QuestionInCreate: QuestionInCreate): Promise<Question> {
         if (QuestionInCreate.choiceList) {
             const setList = new Set(QuestionInCreate.choiceList)
-            if (QuestionInCreate.choiceList.length !== setList.size ) new BadRequestException(`items of choiceList is duplicated`)
+            console.log(QuestionInCreate.choiceList.length , setList.size)
+            if (QuestionInCreate.choiceList.length !== setList.size ) throw new BadRequestException(`items of choiceList is duplicated`)
         }
         return await this.questionRepository.createQuestion(user, QuestionInCreate);
     }


### PR DESCRIPTION
Summary

- question 관련 수정

	1. 홈 피드 게시물 순서 조정 ( isViewed 하단 정렬 제거 )
	2. PersonalQ 생성 과정에서 choiceList validation 

- 나를 차단한 유저 제외 하고 fetch User 진행

	1. 추천 친구 리스트 -> 나를 차단한 유저, 내가 차단한 유저 제외
	3. following 리스트 -> 나를 차단한 유저 제외 ( 내가 차단한 유저는 following 에 미포함 )
	4. fetch -> 나를 차단한 유저 제외 ( 내가 차단한 유저는 같이 나옴 )




